### PR TITLE
Don’t print warnings when reaching dead ends

### DIFF
--- a/src/main/java/com/graphaware/module/noderank/NodeRankModule.java
+++ b/src/main/java/com/graphaware/module/noderank/NodeRankModule.java
@@ -128,8 +128,8 @@ public class NodeRankModule extends BaseRuntimeModule implements TimerDrivenModu
 
         Relationship randomRelationship = relationshipSelector.selectRelationship(currentNode);
         if (randomRelationship == null) {
-            LOG.warn("NodeRank did not find a relationship to follow. Will start from a random node.");
-            return null;
+            LOG.debug("Dead end at {}, selecting a new random node", currentNode);
+            return nodeSelector.selectNode(database);
         }
 
         Node result = randomRelationship.getOtherNode(currentNode);

--- a/src/main/java/com/graphaware/module/noderank/NodeRankModule.java
+++ b/src/main/java/com/graphaware/module/noderank/NodeRankModule.java
@@ -110,7 +110,7 @@ public class NodeRankModule extends BaseRuntimeModule implements TimerDrivenModu
         try {
             return lastContext.find(database);
         } catch (NotFoundException e) {
-            LOG.warn("Node referenced in last context with ID: {} was not found in the database.  Will start from a random node.");
+            LOG.warn("Node referenced in last context with ID {} was not found in the database.  Will start from a random node.", lastContext);
             return null;
         }
     }


### PR DESCRIPTION
Previous behavior has been to simply iterate over and over on a dead-end node until the damping factor causes a jump to a new random node. This seems wildly inefficient, and prints a lot of noise to the log. Instead, log it as a debug and choose a random next node (as the log message actually says.)
