### PR TITLE
Causal cluster 3.1.1 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.graphaware.neo4j</groupId>
         <artifactId>module-parent</artifactId>
-        <version>3.1.3.45-SNAPSHOT</version>
+        <version>3.1.3.45</version>
     </parent>
 
     <name>GraphAware Neo4j Node Rank Module</name>

--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>noderank</artifactId>
-    <version>3.1.0.44.5-SNAPSHOT</version>
+    <version>3.1.3.45.6-SNAPSHOT</version>
 
     <parent>
         <groupId>com.graphaware.neo4j</groupId>
         <artifactId>module-parent</artifactId>
-        <version>3.1.1.45-SNAPSHOT</version>
+        <version>3.1.3.45-SNAPSHOT</version>
     </parent>
 
     <name>GraphAware Neo4j Node Rank Module</name>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.graphaware.neo4j</groupId>
         <artifactId>module-parent</artifactId>
-        <version>3.1.0.44</version>
+        <version>3.1.1.45-SNAPSHOT</version>
     </parent>
 
     <name>GraphAware Neo4j Node Rank Module</name>

--- a/src/main/java/com/graphaware/module/noderank/NodeRankApi.java
+++ b/src/main/java/com/graphaware/module/noderank/NodeRankApi.java
@@ -16,45 +16,65 @@
 
 package com.graphaware.module.noderank;
 
-import com.graphaware.runtime.RuntimeRegistry;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.Validate;
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
-import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.core.GraphProperties;
+import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
-import java.util.LinkedList;
-import java.util.List;
+import com.graphaware.common.serialize.Serializer;
+import com.graphaware.runtime.metadata.DefaultTimerDrivenModuleMetadata;
 
 public class NodeRankApi {
 
-    private final GraphDatabaseService database;
+	private final GraphDatabaseService database;
 
-    public NodeRankApi(GraphDatabaseService database) {
-        this.database = database;
-    }
+	public NodeRankApi(GraphDatabaseService database) {
+		this.database = database;
+	}
 
-    public List<Node> getTopRankedNodes(String moduleId, int limit) {
-        List<Node> result = new LinkedList<>();
-        NodeRankModule module = RuntimeRegistry.getStartedRuntime(database).getModule(moduleId, NodeRankModule.class);
+	/**
+	 * Need to be call during a transaction
+	 * 
+	 * @param moduleId
+	 * @param limit
+	 * @return
+	 */
+	public List<Node> getTopRankedNodes(String moduleId, int limit) {
+		List<Node> result = new LinkedList<>();
 
-        try (Transaction tx = database.beginTx()) {
-            for (Node node : module.getTopNodes().getTopNodes()) {
-                try {
-                    result.add(node);
-
-                    if (result.size() >= limit) {
-                        break;
-                    }
-
-                } catch (NotFoundException e) {
-                    //oh well, deleted in the meantime
-                }
-            }
-
-            tx.success();
-        }
-
-        return result;
-    }
+		DependencyResolver dependencyResolver = ((GraphDatabaseAPI) database).getDependencyResolver();
+		NodeManager resolveDependency = dependencyResolver.resolveDependency(NodeManager.class);		
+		GraphProperties properties = resolveDependency.newGraphProperties();
+		Map<String, Object> allProperties = properties.getAllProperties();
+		List<String> collect = allProperties.keySet().stream().filter(k -> k.contains(moduleId)).collect(Collectors.toList());
+		
+		// not synchronized yet or don't exists
+		if(collect.isEmpty()){
+			throw new NotFoundException("No module with ID " + moduleId + " has been registered");
+		}
+		
+		String key = collect.get(0);
+		Object v = allProperties.get(key);
+		byte[] array = (byte[]) v;
+		DefaultTimerDrivenModuleMetadata metadata = Serializer.fromByteArray(array);
+		NodeRankContext lastContext = (NodeRankContext) metadata.lastContext();
+		if (lastContext != null) {
+			Long[] topNodes = lastContext.getTopNodes();
+			for (Long id : topNodes) {
+				Node node = database.getNodeById(id);
+				result.add(node);
+			}
+		}
+		return result;
+	}
 
 }

--- a/src/main/java/com/graphaware/module/noderank/NodeRankModule.java
+++ b/src/main/java/com/graphaware/module/noderank/NodeRankModule.java
@@ -106,7 +106,7 @@ public class NodeRankModule extends BaseTimerDrivenModule<NodeRankContext> imple
 	public NodeRankContext doSomeWork(NodeRankContext lastContext, GraphDatabaseService database) {
 		NodeRankContext result = lastContext;
 
-		if ( ! new InstanceRoleUtils(database).isReadOnly()) {
+		if ( ! new InstanceRoleUtils(database).getInstaceRole().isReadOnly()) {
 			//when the instance can write, the topNodes are initialized by the context
 			//when the instance become master/leader (after election), starts from sharing data in the context
 			topNodes.initializeIfNeeded(lastContext, database, config);

--- a/src/main/java/com/graphaware/module/noderank/NodeRankModule.java
+++ b/src/main/java/com/graphaware/module/noderank/NodeRankModule.java
@@ -18,6 +18,7 @@ package com.graphaware.module.noderank;
 
 import com.graphaware.common.log.LoggerFactory;
 import com.graphaware.runtime.config.TimerDrivenModuleConfiguration;
+import com.graphaware.runtime.config.util.InstanceRoleUtils;
 import com.graphaware.runtime.metadata.NodeBasedContext;
 import com.graphaware.runtime.module.BaseTimerDrivenModule;
 import com.graphaware.runtime.module.TimerDrivenModule;
@@ -102,23 +103,33 @@ public class NodeRankModule extends BaseTimerDrivenModule<NodeRankContext> imple
      * {@inheritDoc}
      */
     @Override
-    public NodeRankContext doSomeWork(NodeRankContext lastContext, GraphDatabaseService database) {
-        topNodes.initializeIfNeeded(lastContext, database, config);
+	public NodeRankContext doSomeWork(NodeRankContext lastContext, GraphDatabaseService database) {
+		NodeRankContext result = lastContext;
 
-        Node lastNode = determineLastNode(lastContext, database);
-        Node nextNode = determineNextNode(lastNode, database);
+		if ( ! new InstanceRoleUtils(database).isReadOnly()) {
+			//when the instance can write, the topNodes are initialized by the context
+			//when the instance become master/leader (after election), starts from sharing data in the context
+			topNodes.initializeIfNeeded(lastContext, database, config);
 
-        if (nextNode == null) {
-            LOG.debug("NodeRank did not find a node to continue with. There are no nodes matching the configuration.");
-            return lastContext;
-        }
+			Node lastNode = determineLastNode(lastContext, database);
+			Node nextNode = determineNextNode(lastNode, database);
 
-        int rankValue = (int) nextNode.getProperty(config.getRankPropertyKey(), 0) + 1;
-        nextNode.setProperty(config.getRankPropertyKey(), rankValue);
-        topNodes.addNode(nextNode, rankValue);
+			if (nextNode == null) {
+				LOG.debug("NodeRank did not find a node to continue with. There are no nodes matching the configuration.");
+				return lastContext;
+			}
 
-        return new NodeRankContext(nextNode, topNodes.getTopNodeIds());
-    }
+			int rankValue = (int) nextNode.getProperty(config.getRankPropertyKey(), 0) + 1;
+
+			nextNode.setProperty(config.getRankPropertyKey(), rankValue);
+
+			topNodes.addNode(nextNode, rankValue);
+
+			result = new NodeRankContext(nextNode, topNodes.getTopNodeIds());
+		}
+
+		return result;
+	}
 
     private Node determineLastNode(NodeBasedContext lastContext, GraphDatabaseService database) {
         if (lastContext == null) {

--- a/src/main/java/com/graphaware/module/noderank/NodeRankModuleBootstrapper.java
+++ b/src/main/java/com/graphaware/module/noderank/NodeRankModuleBootstrapper.java
@@ -16,19 +16,17 @@
 
 package com.graphaware.module.noderank;
 
+import java.util.Map;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.logging.Log;
+
 import com.graphaware.common.log.LoggerFactory;
-import com.graphaware.common.policy.NodeInclusionPolicy;
-import com.graphaware.common.policy.RelationshipInclusionPolicy;
+import com.graphaware.common.policy.inclusion.NodeInclusionPolicy;
+import com.graphaware.common.policy.inclusion.RelationshipInclusionPolicy;
 import com.graphaware.runtime.config.function.StringToNodeInclusionPolicy;
 import com.graphaware.runtime.config.function.StringToRelationshipInclusionPolicy;
 import com.graphaware.runtime.module.RuntimeModuleBootstrapper;
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.kernel.api.exceptions.KernelException;
-import org.neo4j.kernel.impl.proc.Procedures;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
-import org.neo4j.logging.Log;
-
-import java.util.Map;
 
 /**
  * {@link RuntimeModuleBootstrapper} for {@link NodeRankModule}.

--- a/src/main/java/com/graphaware/module/noderank/NodeRankModuleConfiguration.java
+++ b/src/main/java/com/graphaware/module/noderank/NodeRankModuleConfiguration.java
@@ -39,7 +39,7 @@ public class NodeRankModuleConfiguration extends BaseTimerDrivenModuleConfigurat
      * @return The default {@link NodeRankModuleConfiguration}
      */
     public static NodeRankModuleConfiguration defaultConfiguration() {
-        return new NodeRankModuleConfiguration(InstanceRolePolicy.MASTER_ONLY, "nodeRank", IncludeAllBusinessNodes.getInstance(), IncludeAllBusinessRelationships.getInstance(), 10, 0.85);
+        return new NodeRankModuleConfiguration(InstanceRolePolicy.ANY, "nodeRank", IncludeAllBusinessNodes.getInstance(), IncludeAllBusinessRelationships.getInstance(), 10, 0.85);
     }
 
     /**

--- a/src/main/java/com/graphaware/module/noderank/NodeRankModuleConfiguration.java
+++ b/src/main/java/com/graphaware/module/noderank/NodeRankModuleConfiguration.java
@@ -16,8 +16,10 @@
 
 package com.graphaware.module.noderank;
 
-import com.graphaware.common.policy.NodeInclusionPolicy;
-import com.graphaware.common.policy.RelationshipInclusionPolicy;
+import com.graphaware.common.policy.inclusion.NodeInclusionPolicy;
+import com.graphaware.common.policy.inclusion.RelationshipInclusionPolicy;
+import com.graphaware.common.policy.role.AnyRole;
+import com.graphaware.common.policy.role.InstanceRolePolicy;
 import com.graphaware.runtime.config.BaseTimerDrivenModuleConfiguration;
 import com.graphaware.runtime.policy.all.IncludeAllBusinessNodes;
 import com.graphaware.runtime.policy.all.IncludeAllBusinessRelationships;
@@ -39,7 +41,7 @@ public class NodeRankModuleConfiguration extends BaseTimerDrivenModuleConfigurat
      * @return The default {@link NodeRankModuleConfiguration}
      */
     public static NodeRankModuleConfiguration defaultConfiguration() {
-        return new NodeRankModuleConfiguration(InstanceRolePolicy.ANY, "nodeRank", IncludeAllBusinessNodes.getInstance(), IncludeAllBusinessRelationships.getInstance(), 10, 0.85);
+        return new NodeRankModuleConfiguration(AnyRole.getInstance(), "nodeRank", IncludeAllBusinessNodes.getInstance(), IncludeAllBusinessRelationships.getInstance(), 10, 0.85);
     }
 
     /**

--- a/src/test/java/com/graphaware/module/noderank/NodeRankModuleTest.java
+++ b/src/test/java/com/graphaware/module/noderank/NodeRankModuleTest.java
@@ -16,18 +16,23 @@
 
 package com.graphaware.module.noderank;
 
-import com.graphaware.common.policy.BaseRelationshipInclusionPolicy;
-import com.graphaware.common.policy.fluent.IncludeNodes;
-import com.graphaware.runtime.metadata.NodeBasedContext;
-import com.graphaware.test.integration.DatabaseIntegrationTest;
-import com.graphaware.test.integration.EmbeddedDatabaseIntegrationTest;
-import org.junit.Test;
-import org.neo4j.graphdb.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+
+import com.graphaware.common.policy.inclusion.BaseRelationshipInclusionPolicy;
+import com.graphaware.common.policy.inclusion.fluent.IncludeNodes;
+import com.graphaware.runtime.metadata.NodeBasedContext;
+import com.graphaware.test.integration.EmbeddedDatabaseIntegrationTest;
 
 public class NodeRankModuleTest extends EmbeddedDatabaseIntegrationTest {
 

--- a/src/test/java/com/graphaware/module/noderank/NodeRankProcedureTestCausalCluster.java
+++ b/src/test/java/com/graphaware/module/noderank/NodeRankProcedureTestCausalCluster.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2013-2016 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of
+ * the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.graphaware.module.noderank;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.proc.Procedures;
+
+import com.graphaware.runtime.GraphAwareRuntime;
+import com.graphaware.runtime.GraphAwareRuntimeFactory;
+import com.graphaware.runtime.config.TimerDrivenModuleConfiguration;
+import com.graphaware.test.data.DatabasePopulator;
+import com.graphaware.test.integration.cluster.CausalClusterDatabasesintegrationTest;
+
+/**
+ *
+ */
+public class NodeRankProcedureTestCausalCluster extends CausalClusterDatabasesintegrationTest {
+	
+	private static boolean initialized = false;
+	
+	@Override
+	protected boolean shouldRegisterModules() {
+		return true;
+	}
+
+	@Override
+	protected boolean shouldRegisterProcedures() {
+		return true;
+	}
+	
+	@Override
+	protected void registerModule(GraphDatabaseService db) throws Exception {
+		GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(db);
+        NodeRankModuleConfiguration config = NodeRankModuleConfiguration.defaultConfiguration()
+        .with(TimerDrivenModuleConfiguration.InstanceRolePolicy.LEADER_ONLY)
+        .withMaxTopRankNodes(3);
+		runtime.registerModule(new NodeRankModule("noderank",config));
+        runtime.start();
+	}
+
+	@Override
+	protected void registerProcedures(Procedures procedures) throws Exception {
+		procedures.registerProcedure(NodeRankProcedure.class);
+	}
+	
+	@Override
+	protected DatabasePopulator databasePopulator() {
+		return new DatabasePopulator() {
+			
+			@Override
+			public void populate(GraphDatabaseService database) {
+				try(Transaction tx = database.beginTx();){
+	            database.execute("CREATE (m:Person {name:'Michal'})-[:FRIEND_OF]->(d:Person {name:'Daniela'})," +
+	                    " (m)-[:FRIEND_OF]->(v:Person {name:'Vojta'})," +
+	                    " (m)-[:FRIEND_OF]->(a:Person {name:'Adam'})," +
+	                    " (m)-[:FRIEND_OF]->(vi:Person {name:'Vince'})," +
+	                    " (m)-[:FRIEND_OF]->(:Person {name:'Luanne'})," +
+	                    " (vi)-[:FRIEND_OF]->(a)," +
+	                    " (d)-[:FRIEND_OF]->(a)," +
+	                    " (d)-[:FRIEND_OF]->(vi)," +
+	                    " (v)-[:FRIEND_OF]->(a)");
+	            tx.success();
+				}
+				
+			}
+		};
+	}
+	
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		if(! initialized){
+			
+			GraphDatabaseService database = getOneReplicaDatabase();
+			//wait for ranking synch to replica
+			int count = 0;
+			do{
+				count = 0;
+		        try (Transaction tx = database.beginTx()) {
+		            Result result = database.execute("MATCH (node:Person) RETURN node");
+//		            System.out.println("======================");
+		            while(result.hasNext()){
+		            	Node node = (Node) result.next().get("node");
+		            	if(node.hasProperty("nodeRank")){
+		            		Integer rank = (Integer) node.getProperty("nodeRank");
+//		            		System.out.println(node.getProperty("name")+": "+node.getProperty("nodeRank"));
+		            		if(rank > 2){
+		            			count++;			            			
+		            		}
+		            	}
+		            }
+		            tx.failure();
+		        }catch(Exception e){e.printStackTrace();}
+		        
+		        try {
+		        	TimeUnit.SECONDS.sleep(1);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}while( count < 6 );
+			
+			initialized = true;
+		}
+	}
+	
+    @Test
+    public void testProcedureCall_LEADER() throws InterruptedException, IOException {
+        GraphDatabaseService database = getLeaderDatabase();
+        try (Transaction tx = database.beginTx()) {
+            Result result = database.execute("CALL ga.noderank.getTopRanked('noderank', 10) YIELD node RETURN node");
+            List<Node> ranked = new LinkedList<>();
+            while (result.hasNext()) {
+                Map<String, Object> record = result.next();
+                ranked.add((Node) record.get("node"));
+            }
+            assertFalse("No ranked nodes found",ranked.isEmpty());
+            assertEquals("Michal", ranked.get(0).getProperty("name"));
+            tx.failure();
+        }
+    }
+	
+    @Test
+    public void testProcedureCall_FOLLOWER() throws InterruptedException, IOException {
+        GraphDatabaseService database = getOneFollowerDatabase();
+        try (Transaction tx = database.beginTx()) {
+            Result result = database.execute("CALL ga.noderank.getTopRanked('noderank', 10) YIELD node RETURN node");
+            List<Node> ranked = new LinkedList<>();
+            while (result.hasNext()) {
+                Map<String, Object> record = result.next();
+                ranked.add((Node) record.get("node"));
+            }
+            assertFalse("No ranked nodes found",ranked.isEmpty());
+            assertEquals("Michal", ranked.get(0).getProperty("name"));
+            tx.failure();
+        }
+    }
+    
+	
+    @Test
+    public void testProcedureCall_REPLICA() throws InterruptedException, IOException {
+        GraphDatabaseService database = getOneReplicaDatabase();
+        try (Transaction tx = database.beginTx()) {
+            Result result = database.execute("CALL ga.noderank.getTopRanked('noderank', 10) YIELD node RETURN node");
+            List<Node> ranked = new LinkedList<>();
+            while (result.hasNext()) {
+                Map<String, Object> record = result.next();
+                ranked.add((Node) record.get("node"));
+            }
+            assertFalse("No ranked nodes found",ranked.isEmpty());
+            assertEquals("Michal", ranked.get(0).getProperty("name"));
+            tx.failure();
+        }
+    }
+}

--- a/src/test/java/com/graphaware/module/noderank/NodeRankProcedureTestCausalCluster.java
+++ b/src/test/java/com/graphaware/module/noderank/NodeRankProcedureTestCausalCluster.java
@@ -31,9 +31,9 @@ import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.proc.Procedures;
 
+import com.graphaware.common.policy.role.WritableRole;
 import com.graphaware.runtime.GraphAwareRuntime;
 import com.graphaware.runtime.GraphAwareRuntimeFactory;
-import com.graphaware.runtime.config.TimerDrivenModuleConfiguration;
 import com.graphaware.test.data.DatabasePopulator;
 import com.graphaware.test.integration.cluster.CausalClusterDatabasesintegrationTest;
 
@@ -58,7 +58,7 @@ public class NodeRankProcedureTestCausalCluster extends CausalClusterDatabasesin
 	protected void registerModule(GraphDatabaseService db) throws Exception {
 		GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(db);
         NodeRankModuleConfiguration config = NodeRankModuleConfiguration.defaultConfiguration()
-        .with(TimerDrivenModuleConfiguration.InstanceRolePolicy.LEADER_ONLY)
+        .with(WritableRole.getInstance())
         .withMaxTopRankNodes(3);
 		runtime.registerModule(new NodeRankModule("noderank",config));
         runtime.start();

--- a/src/test/java/com/graphaware/module/noderank/NodeRankProcedureTestHighAvailability.java
+++ b/src/test/java/com/graphaware/module/noderank/NodeRankProcedureTestHighAvailability.java
@@ -15,7 +15,8 @@
  */
 package com.graphaware.module.noderank;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.util.LinkedList;
@@ -30,9 +31,9 @@ import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.proc.Procedures;
 
+import com.graphaware.common.policy.role.MasterOnly;
 import com.graphaware.runtime.GraphAwareRuntime;
 import com.graphaware.runtime.GraphAwareRuntimeFactory;
-import com.graphaware.runtime.config.TimerDrivenModuleConfiguration;
 import com.graphaware.test.data.DatabasePopulator;
 import com.graphaware.test.integration.cluster.HighAvailabilityClusterDatabasesIntegrationTest;
 
@@ -55,7 +56,7 @@ public class NodeRankProcedureTestHighAvailability extends HighAvailabilityClust
 	protected void registerModule(GraphDatabaseService db) throws Exception {
 		GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(db);
 		NodeRankModuleConfiguration config = NodeRankModuleConfiguration.defaultConfiguration()
-		        .with(TimerDrivenModuleConfiguration.InstanceRolePolicy.MASTER_ONLY)
+		        .with(MasterOnly.getInstance())
 		        .withMaxTopRankNodes(3);
 		runtime.registerModule(new NodeRankModule("noderank",config));
         runtime.start();

--- a/src/test/java/com/graphaware/module/noderank/NodeRankProcedureTestHighAvailability.java
+++ b/src/test/java/com/graphaware/module/noderank/NodeRankProcedureTestHighAvailability.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2013-2016 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of
+ * the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.graphaware.module.noderank;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.proc.Procedures;
+
+import com.graphaware.runtime.GraphAwareRuntime;
+import com.graphaware.runtime.GraphAwareRuntimeFactory;
+import com.graphaware.runtime.config.TimerDrivenModuleConfiguration;
+import com.graphaware.test.data.DatabasePopulator;
+import com.graphaware.test.integration.cluster.HighAvailabilityClusterDatabasesIntegrationTest;
+
+/**
+ *
+ */
+public class NodeRankProcedureTestHighAvailability extends HighAvailabilityClusterDatabasesIntegrationTest {
+
+	@Override
+	protected boolean shouldRegisterModules() {
+		return true;
+	}
+
+	@Override
+	protected boolean shouldRegisterProcedures() {
+		return true;
+	}
+	
+	@Override
+	protected void registerModule(GraphDatabaseService db) throws Exception {
+		GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(db);
+		NodeRankModuleConfiguration config = NodeRankModuleConfiguration.defaultConfiguration()
+		        .with(TimerDrivenModuleConfiguration.InstanceRolePolicy.MASTER_ONLY)
+		        .withMaxTopRankNodes(3);
+		runtime.registerModule(new NodeRankModule("noderank",config));
+        runtime.start();
+	}
+
+	@Override
+	protected void registerProcedures(Procedures procedures) throws Exception {
+		procedures.registerProcedure(NodeRankProcedure.class);
+	}
+	
+	@Override
+	protected DatabasePopulator databasePopulator() {
+		return new DatabasePopulator() {
+			
+			@Override
+			public void populate(GraphDatabaseService database) {
+				try(Transaction tx = database.beginTx();){
+	            database.execute("CREATE (m:Person {name:'Michal'})-[:FRIEND_OF]->(d:Person {name:'Daniela'})," +
+	                    " (m)-[:FRIEND_OF]->(v:Person {name:'Vojta'})," +
+	                    " (m)-[:FRIEND_OF]->(a:Person {name:'Adam'})," +
+	                    " (m)-[:FRIEND_OF]->(vi:Person {name:'Vince'})," +
+	                    " (m)-[:FRIEND_OF]->(:Person {name:'Luanne'})," +
+	                    " (vi)-[:FRIEND_OF]->(a)," +
+	                    " (d)-[:FRIEND_OF]->(a)," +
+	                    " (d)-[:FRIEND_OF]->(vi)," +
+	                    " (v)-[:FRIEND_OF]->(a)");
+	            tx.success();
+				}
+				
+				//wait for ranking
+				int count = 0;
+				do{
+					count = 0;
+			        try (Transaction tx = database.beginTx()) {
+			            Result result = database.execute("MATCH (node:Person) RETURN node");
+//			            System.out.println("======================");
+			            while(result.hasNext()){
+			            	Node node = (Node) result.next().get("node");
+			            	if(node.hasProperty("nodeRank")){
+			            		Integer rank = (Integer) node.getProperty("nodeRank");
+//			            		System.out.println(node.getProperty("name")+": "+node.getProperty("nodeRank"));
+			            		if(rank > 10){
+			            			count++;			            			
+			            		}
+			            	}
+			            }
+			            
+			        }catch(Exception e){e.printStackTrace();}
+			        
+			        try {
+			        	TimeUnit.SECONDS.sleep(1);
+					} catch (InterruptedException e) {
+						e.printStackTrace();
+					}
+				}while( count < 6 );
+			}
+		};
+	}
+	
+    @Test
+    public void testProcedureCall_MASTER() throws InterruptedException, IOException {
+        GraphDatabaseService database = getMasterDatabase();
+        try (Transaction tx = database.beginTx()) {
+            Result result = database.execute("CALL ga.noderank.getTopRanked('noderank', 10) YIELD node RETURN node");
+            List<Node> ranked = new LinkedList<>();
+            while (result.hasNext()) {
+                Map<String, Object> record = result.next();
+                ranked.add((Node) record.get("node"));
+            }
+            assertFalse(ranked.isEmpty());
+            assertEquals("Michal", ranked.get(0).getProperty("name"));
+            tx.failure();
+        }
+    }
+	
+    @Test
+    public void testProcedureCall_SLAVE() throws InterruptedException, IOException {
+        GraphDatabaseService database = getOneSlaveDatabase();
+        try (Transaction tx = database.beginTx()) {
+            Result result = database.execute("CALL ga.noderank.getTopRanked('noderank', 10) YIELD node RETURN node");
+            List<Node> ranked = new LinkedList<>();
+            while (result.hasNext()) {
+                Map<String, Object> record = result.next();
+                ranked.add((Node) record.get("node"));
+            }
+            assertFalse("No ranked nodes found",ranked.isEmpty());
+            assertEquals("Michal", ranked.get(0).getProperty("name"));
+            tx.failure();
+        }
+    }
+}


### PR DESCRIPTION
Changed implementation of API to work with context because the in-memory topnodes can't be aligned in all the cluster instances. Allow module work only on writable instances